### PR TITLE
The yum-cron role name has changed in the galaxy update.

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 - src: dev-sec.os-hardening
-- src: linuxhq.yum-cron
+- src: linuxhq.yum_cron
 - src: https://github.com/lazzurs/ansible-ssh-hardening
   version: feature/password_key_2fa
 - src: singleplatform-eng.users


### PR DESCRIPTION
The yum cron role name we use for keeping redhat boxes up to
date has changed from yum-cron to yum_cron.