### PR TITLE
Allow SSH agent forwarding.

### DIFF
--- a/group_vars/bastion
+++ b/group_vars/bastion
@@ -2,6 +2,7 @@ ssh_use_pam: true
 ssh_allow_tcp_forwarding: true
 ssh_server_password_login: true
 ssh_key_pass_2fa: true
+ssh_allow_agent_forwarding: true
 
 groups_to_create:
   - name: webops


### PR DESCRIPTION
This will allow SSH agent forwarding as some users use the SSH agent.

This might be worth enabling only for dev in future.