### PR TITLE
The sudo rolename has changed.

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -5,4 +5,4 @@
     - singleplatform-eng.users
     - jeffwidman.yum-cron
     - ansible-ssh-hardening
-    - franklinkim.sudo
+    - weareinteractive.sudo

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@
 - src: https://github.com/lazzurs/ansible-ssh-hardening
   version: feature/password_key_2fa
 - src: singleplatform-eng.users
-- src: franklinkim.sudo
+- src: weareinteractive.sudo


### PR DESCRIPTION
From the role docs...

Since Ansible Galaxy supports organization now, this role has moved from franklinkim.sudo to weareinteractive.sudo!

https://github.com/weareinteractive/ansible-sudo