### PR TITLE
Use private name for dev bastion in ansible inventory

### DIFF
--- a/inventory/dev
+++ b/inventory/dev
@@ -1,5 +1,5 @@
 [bastion]
-ssh.bastion-dev.probation.hmpps.dsd.io
+bastion.engineering-dev.internal
 
 [dev]
-ssh.bastion-dev.probation.hmpps.dsd.io
+bastion.engineering-dev.internal


### PR DESCRIPTION
Work item: nit452
With the switch away from a public dev bastion, this is required to enable CI servers to resolve the dev bastion name to an IP in order to run ansible. 